### PR TITLE
Add url for swupd in builder.conf

### DIFF
--- a/builder.conf
+++ b/builder.conf
@@ -2,3 +2,9 @@
 SERVER_STATE_DIR = /var/lib/update
 BUNDLE_DIR = /home/clr/mix/bundles
 YUM_CONF = /usr/share/defaults/bundle-chroot-builder/yum.conf
+
+[URL]
+URL=https://download.clearlinux.org/update/
+CONTENTURL=https://download.clearlinux.org/update/
+VERSIONURL=https://download.clearlinux.org/update/
+FORMAT=3

--- a/bundle-chroot-builder.py
+++ b/bundle-chroot-builder.py
@@ -271,6 +271,32 @@ def create_chroots(args, state_dir, bundles, yum_conf):
     for r in results_list:
         r.get()
 
+    """Read the URL values from builder.conf and insert them into os-core-update to swupd knows where to pull content from"""
+    buildconf='/usr/share/defaults/bundle-chroot-builder/builder.conf'
+    if os.path.isfile('/etc/bundle-chroot-builder/builder.conf'):
+        buildconf = '/etc/bundle-chroot-builder/builder.conf'
+    if args.config:
+        buildconf = args.config
+    config = configparser.ConfigParser()
+    config.read(buildconf)
+
+    """Read the configuration file for our script values"""
+    conf = config['URL']
+    url = conf['URL']
+    contenturl = conf['CONTENTURL']
+    versionurl = conf['VERSIONURL']
+    formatname = conf['FORMAT']
+
+    os.mkdir(out_dir + "/os-core-update/usr/share/defaults/swupd/")
+    with open(out_dir + "/os-core-update/usr/share/defaults/swupd/url", "w") as file:
+        file.writelines(url)
+    with open(out_dir + "/os-core-update/usr/share/defaults/swupd/contenturl", "w") as file:
+        file.writelines(contenturl)
+    with open(out_dir + "/os-core-update/usr/share/defaults/swupd/versionurl", "w") as file:
+        file.writelines(versionurl)
+    with open(out_dir + "/os-core-update/usr/share/defaults/swupd/format", "w") as file:
+        file.writelines(formatname)
+
     print("Creating package to file mappings")
     package_mapping = {}
     map_files = [f for f in os.listdir(out_dir) if f.startswith("pkgmap-")]


### PR DESCRIPTION
The update client currently defaults to the public clearlinux url, and must be
overridden with cmd line options to use other version/content/format urls. This
introduces a problem when running a mix, and not supplying the mix URL will
cause swupd to update from the official URL, rather than the mixer url.
With this patch, the URLs can all be specified and are inserted into conf files
that the swupd client will read, to know what URL to default to.

Signed-off-by: Tudor Marcu tudor.marcu@intel.com
