### PR TITLE
Fix whitespace issue with pkg name

### DIFF
--- a/bundle-chroot-builder.py
+++ b/bundle-chroot-builder.py
@@ -80,6 +80,7 @@ def install_bundle(out_dir, postfix, bundle, bundles, yum_cmd):
     pkgs = "".join(lines)
     to_install = []
     for pkg in pkgs.splitlines():
+        pkg = pkg.decode("utf-8").strip()
         # Don't add blank lines or lines with leading '#'
         if len(pkg) == 0 or pkg[0] == "#":
             continue

--- a/bundle-chroot-builder.py
+++ b/bundle-chroot-builder.py
@@ -80,7 +80,7 @@ def install_bundle(out_dir, postfix, bundle, bundles, yum_cmd):
     pkgs = "".join(lines)
     to_install = []
     for pkg in pkgs.splitlines():
-        pkg = pkg.decode("utf-8").strip()
+        pkg = pkg.strip()
         # Don't add blank lines or lines with leading '#'
         if len(pkg) == 0 or pkg[0] == "#":
             continue


### PR DESCRIPTION
Preceeding or trailing whitespaces must be stripped

Signed-off-by: Brad T. Peters brad.t.peters@intel.com
