### PR TITLE
Add progress messages for builder.conf values

### DIFF
--- a/bundle-chroot-builder.py
+++ b/bundle-chroot-builder.py
@@ -302,15 +302,19 @@ def create_chroots(args, state_dir, bundles, yum_conf):
     versionurl = conf['VERSIONURL']
     formatname = conf['FORMAT']
 
+    print("Adding SWUPD default values to '{}' bundle...".format(bundlename))
     """Do not add a leading slash on anything except the first variable in os.path.join!"""
     confpath = os.path.join(out_dir, bundlename, "usr/share/defaults/swupd/")
     os.makedirs(confpath, exist_ok=True)
     with open(os.path.join(confpath, "contenturl"), "w") as file:
         file.writelines(contenturl)
+    print("  contenturl: {}".format(contenturl))
     with open(os.path.join(confpath, "versionurl"), "w") as file:
         file.writelines(versionurl)
+    print("  versionurl: {}".format(versionurl))
     with open(os.path.join(confpath, "format"), "w") as file:
         file.writelines(formatname)
+    print("  format: {}".format(formatname))
 
     print("Creating package to file mappings")
     package_mapping = {}


### PR DESCRIPTION
To help debug issues related to SWUPD config values being set in the
chroot, or not, print out diagnostic messages to display the expected
values.

Signed-off-by: Patrick McCarty patrick.mccarty@intel.com
