### PR TITLE
Exclude empty subpackages from the SRPM file lists

### DIFF
--- a/bundle-chroot-builder.py
+++ b/bundle-chroot-builder.py
@@ -331,6 +331,10 @@ def create_chroots(args, state_dir, bundles, yum_conf):
         if package_name not in package_mapping:
             package_mapping[package_name] = set()
         for path in path_list:
+            # RPM prints out a specific string for subpackages that contain no
+            # files. It should be excluded from the SRPM file list.
+            if re.match(br"\(contains no files\)\n", path):
+                continue
             package_mapping[package_name].add(path)
     for package_name, paths in package_mapping.items():
         with open(out_dir + "/files-{}".format(package_name), "wb") as file:


### PR DESCRIPTION
The string "(contains no files)" is printed when running 'rpm -ql ...'
for an empty subpackage. Since that output is more useful for
interactive use, make sure the string is excluded from the final SRPM
file lists that begin with files-*.