### PR TITLE
Exit on m4 error

### DIFF
--- a/bundle-chroot-builder.py
+++ b/bundle-chroot-builder.py
@@ -74,9 +74,13 @@ def read_config(args):
 def install_bundle(out_dir, postfix, bundle, bundles, yum_cmd):
     """Helper function to yum install a bundle"""
     lines = []
-    with subprocess.Popen(["m4", bundles + "/" + bundle], cwd=bundles, stdout=subprocess.PIPE, bufsize=1, universal_newlines=True) as p:
-        for line in p.stdout:
-            lines.append(line)
+    try:
+        output = subprocess.check_output(["m4", bundles + "/" + bundle], cwd=bundles, bufsize=1, universal_newlines=True)
+    except subprocess.CalledProcessError as e:
+        print('ERROR {0}: m4 failed on {1}/{2}'.format(e.returncode, bundles, bundle))
+        raise
+    for line in output:
+        lines.append(line)
 
     pkgs = "".join(lines)
     to_install = []


### PR DESCRIPTION
M4 may fail here in the case of circular includes, causing the updater
to crash later. This patch checks that the subprocess call succeeded, and if not
raises an exception to exit. It may not terminate instantly due to the async
nature of processing bundles, but once the bad thread finishes it will exit.

Signed-off-by: Tudor Marcu <tudor.marcu@intel.com>