### PR TITLE
Add debuginfo configuration for server.ini

### DIFF
--- a/builder.conf
+++ b/builder.conf
@@ -10,3 +10,8 @@ BUNDLE=os-core-update
 CONTENTURL=<URL where the content will be hosted>
 VERSIONURL=<URL where the version of the mix will be hosted>
 FORMAT=1
+
+[Server]
+debuginfo_banned=true
+debuginfo_lib=/usr/lib/debug/
+debuginfo_src=/usr/src/debug/


### PR DESCRIPTION
Add configuration for debuginfo bans to server.ini via builder.conf.
These configurations will be directly used by swupd-server to determine
if it should ban debuginfo files from the manifests and exactly which
paths should be banned. This patch cleans up the writing of the
server.ini file as well.

Signed-off-by: Matthew Johnson <matthew.johnson@intel.com>