### PR TITLE
Allow yum plugin usage

### DIFF
--- a/bundle-chroot-builder.py
+++ b/bundle-chroot-builder.py
@@ -254,7 +254,7 @@ def create_chroots(args, state_dir, bundles, yum_conf):
         packager = ["dnf"]
     else:
         packager = ["yum"]
-    yum_cmd = packager + ["--config={}".format(yum_conf), "-y", "--noplugins", "--releasever={}".format(build_version)]
+    yum_cmd = packager + ["--config={}".format(yum_conf), "-y", "--releasever={}".format(build_version)]
     if 'local' in config == False:
         try:
             urllib.request.urlopen(conf_baseurl)


### PR DESCRIPTION
When doing a yum install, plugins should be able to modify how this
operation is performed.  Allowing the use of a priority plugin, or a
fastest mirror plugin, or other possibly useful plugins would be up to
the user and dependent on the yum configuration they use for building
the chroot for their bundles.

Signed-off-by: George T Kramer <george.t.kramer@intel.com>